### PR TITLE
LPD-96496 LPD-48290 Rebuild the publisher profile page per Figma

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-apps/index.css
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-apps/index.css
@@ -8,15 +8,58 @@
 	padding: var(--spacer-3);
 }
 
-.publisher-profile-apps-fragment .publisher-profile-app-image {
-	border-radius: 8px;
-	object-fit: cover;
+.publisher-profile-apps-fragment .publisher-profile-app-card-hidden {
+	display: none !important;
 }
 
-.publisher-profile-apps-fragment .publisher-profile-app-name {
-	-webkit-box-orient: vertical;
-	-webkit-line-clamp: 2;
-	display: -webkit-box;
-	overflow: hidden;
-	text-overflow: ellipsis;
+
+.publisher-profile-apps-fragment .publisher-profile-apps-page-size {
+	background-color: transparent;
+	border: 0;
+	color: #2b3a4b;
+	font-size: 14px;
+	font-weight: 600;
+}
+
+.publisher-profile-apps-fragment .publisher-profile-apps-pagination .lexicon-icon {
+	height: 16px;
+	margin-top: 0;
+	width: 16px;
+}
+
+.publisher-profile-apps-fragment .publisher-profile-apps-pagination .page-item.active .page-link {
+	background-color: #d5d8db;
+	color: #3d536b;
+}
+
+.publisher-profile-apps-fragment .publisher-profile-apps-pagination .page-item.disabled .page-link {
+	opacity: 0.5;
+}
+
+.publisher-profile-apps-fragment .publisher-profile-apps-pagination .page-link {
+	background-color: transparent;
+	border: 0;
+	border-radius: 6px;
+	color: #2b3a4b;
+	font-size: 14px;
+	font-weight: 600;
+	line-height: 16px;
+	padding: 8px 12px;
+}
+
+.publisher-profile-apps-fragment .publisher-profile-apps-results {
+	font-size: 13px;
+	line-height: 16px;
+}
+
+.publisher-profile-apps-fragment .publisher-profile-apps-results-range {
+	color: #282934;
+}
+
+.publisher-profile-apps-fragment .publisher-profile-apps-results-total {
+	color: #54555f;
+}
+
+.publisher-profile-apps-fragment .stars {
+	color: var(--color-accent-6);
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-apps/index.html
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-apps/index.html
@@ -41,28 +41,152 @@
 	[#return "" /]
 [/#function]
 
+[#function langKey label]
+	[#return label?lower_case?replace(" ", "-", "r")?replace("&", "and", "r")?replace(",", "", "r")?replace("/", "-", "r") /]
+[/#function]
+
 <div class="publisher-profile-apps-fragment">
 	[#if publisherName?has_content && channelId?has_content]
-		[#assign response = restClient.get("/headless-commerce-delivery-catalog/v1.0/channels/${channelId}/products?accountId=-1&nestedFields=productSpecifications&pageSize=100") /]
+		[#assign response = restClient.get("/headless-commerce-delivery-catalog/v1.0/channels/${channelId}/products?accountId=-1&nestedFields=categories,productSpecifications&pageSize=100") /]
 		[#assign publisherProducts = (response.items![])?filter(product -> getPublisherName(product) == publisherName) /]
 
 		[#if publisherProducts?has_content]
-			<h4 class="font-weight-semi-bold mb-3 mt-5">
-				${languageUtil.get(locale, "apps", "Apps")} (${publisherProducts?size})
+			<h4 class="font-weight-semi-bold mb-3 publisher-profile-apps-title">
+				${languageUtil.get(locale, "applications", "Applications")}
 			</h4>
 
 			<div class="d-flex flex-row flex-wrap publisher-profile-apps">
 				[#list publisherProducts as product]
-					<a class="d-flex flex-column mb-0 one-card position-relative publisher-profile-app-card text-dark text-decoration-none" href="/p/${product.slug}" target="_self">
-						<div class="align-items-center d-flex flex-row">
-							<div class="image-container mr-3 rounded">
-								<img alt="${product.name}" class="publisher-profile-app-image" draggable="false" height="48" src="${((product.urlImage!'')?replace('https://', 'http://'))?js_string}" width="48" />
+					[#assign remainingCategoriesText = [] /]
+
+					[#if product.categories?has_content]
+						[#assign productCategories = product.categories?filter(productCategory -> productCategory.vocabulary?replace(" ", "-") == "marketplace-app-category")![] categoriesListSize = productCategories?size-1 productTypes = product.categories?filter(productCategory -> productCategory.vocabulary?replace(" ", "-") == "marketplace-category")![] /]
+					[/#if]
+
+					[#assign productType = productTypes[0]!"" /]
+
+					[#if product.productSpecifications?has_content]
+						[#assign productSpecifications = product.productSpecifications![] /]
+
+						[#function getSpecificationValue key defaultValue=""]
+							[#local specification = productSpecifications?filter(productSpecification ->
+								stringUtil.equals(productSpecification.specificationKey, key)) /]
+
+							[#return (specification?first.value)!defaultValue /]
+						[/#function]
+					[/#if]
+
+					[#assign productDescription = stringUtil.shorten(htmlUtil.stripHtml(product.description!""), 140, "...") /]
+
+					[#assign productIcon = getSpecificationValue("product-icon", "liferay_waffle") /]
+
+					<a class="app-card d-flex flex-column mb-0 one-card position-relative publisher-profile-app-card text-dark text-decoration-none" href="/p/${product.slug}" target="_self">
+						<div class="card-image-title-container d-flex">
+							<div class="image-container mr-2 rounded">
+								<img alt="${product.name}" class="app-search-image" draggable="false" height="48" lazy="true" src="/documents/d${themeDisplay.getScopeGroup().getFriendlyURL()}/${productIcon}-svg" width="48" />
 							</div>
 
-							<div class="font-weight-semi-bold publisher-profile-app-name">${product.name}</div>
+							<div class="d-flex flex-column w-100">
+								[#if productType?has_content]
+									<span class="d-flex justify-content-end">
+										[#if productType.title == 'Other']
+											<div class="app-type-badge"></div>
+										[#else]
+											[#assign badgeType = productType.name?lower_case?replace(" ", "-", "r")?replace("/", "-", "r")]
+
+											<div class="app-type-badge ${badgeType} font-weight-semi-bold">
+												${languageUtil.get(locale, langKey(productType.title), productType.title)}
+											</div>
+										[/#if]
+									</span>
+								[/#if]
+
+								<div class="app-name font-weight-semi-bold mb-1">
+									${product.name}
+								</div>
+
+								<div class="catalog-name font-weight-normal mt-0 text-black-50">
+									${getSpecificationValue("developer-name")}
+								</div>
+							</div>
+						</div>
+
+						<div class="d-flex flex-column font-size-paragraph-small h-100 justify-content-between">
+							<div class="app-card-description font-weight-normal my-3">
+								${productDescription}
+							</div>
+
+							<div class="d-flex flex-column">
+								<div class="font-weight-semi-bold mb-3 text-capitalize">
+									${getSpecificationValue("price-model")}
+								</div>
+
+								[#if productCategories?has_content]
+									[#assign principalCategory = productCategories[0] remainingCategories = productCategories?filter(category -> category.name != principalCategory.name) /]
+
+									[#list remainingCategories as category]
+										[#assign remainingCategoriesText = remainingCategoriesText + [languageUtil.get(locale, langKey(category.title), category.title)] /]
+									[/#list]
+								[/#if]
+
+								[#if principalCategory?has_content]
+									[#assign principalCategoryTitle = languageUtil.get(locale, langKey(principalCategory.title), principalCategory.title) tagName = stringUtil.shorten(htmlUtil.stripHtml(principalCategoryTitle!""), 100, "...") /]
+
+									<div class="my-1 tags-container">
+										<span class="font-weight-normal mb-3 mr-3 product-tag px-2 py-1 rounded text-nowrap" title="${principalCategoryTitle}">
+											${tagName}
+										</span>
+
+										[#if categoriesListSize?has_content && remainingCategoriesText?has_content]
+											<span class="font-weight-normal mb-1 product-tag px-2 py-1 rounded text-nowrap" title="${remainingCategoriesText?join('\n')}">
+												+ ${categoriesListSize}
+											</span>
+										[/#if]
+									</div>
+								[/#if]
+
+								[#if configuration.hideRatingInfo == false]
+									<div class="d-flex flex-row justify-content-between mt-2">
+										<div class="align-items-center d-flex justify-content-center">
+											<span class="stars">
+												[@clay["icon"] symbol="star" /]
+												[@clay["icon"] symbol="star" /]
+												[@clay["icon"] symbol="star" /]
+												[@clay["icon"] symbol="star-half" /]
+												[@clay["icon"] symbol="star-o" /]
+											</span>
+
+											<p class="m-0 ml-1">4.85 (200)</p>
+										</div>
+
+										<div class="align-items-center d-flex justify-content-center">
+											[@clay["icon"] symbol="download" /]
+
+											<span class="m-0 ml-1">85k</span>
+										</div>
+									</div>
+								[/#if]
+							</div>
 						</div>
 					</a>
 				[/#list]
+			</div>
+
+			<div class="align-items-center d-flex flex-wrap justify-content-between mt-4 publisher-profile-apps-pagination-bar">
+				<div class="align-items-center d-flex">
+					<select aria-label="${languageUtil.get(locale, "entries-per-page", "Entries per Page")}" class="mr-3 publisher-profile-apps-page-size">
+						[#list [4, 8, 12, 24, 48] as delta]
+							<option [#if delta?string == (configuration.pageSize!8)?string]selected [/#if]value="${delta}">${delta} ${languageUtil.get(locale, "entries", "entries")?lower_case}</option>
+						[/#list]
+					</select>
+
+					<span class="publisher-profile-apps-results">
+						<span class="publisher-profile-apps-results-range" data-template="${languageUtil.get(locale, "showing-x-to-x", "Showing {0} to {1}")}"></span>
+						<span class="publisher-profile-apps-results-total" data-template="${languageUtil.get(locale, "of-x-entries", "of {0} entries")?lower_case}"></span>
+					</span>
+				</div>
+
+				<ul aria-label="${languageUtil.get(locale, "pagination", "Pagination")}" class="mb-0 pagination publisher-profile-apps-pagination" data-spritemap="${themeDisplay.getPathThemeSpritemap()}"></ul>
 			</div>
 		[/#if]
 	[/#if]

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-apps/index.js
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-apps/index.js
@@ -2,3 +2,138 @@
  * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
+
+const appCards = fragmentElement.querySelectorAll('.publisher-profile-app-card');
+const paginationBarElement = fragmentElement.querySelector(
+	'.publisher-profile-apps-pagination-bar'
+);
+
+if (appCards.length && paginationBarElement) {
+	const pageSizeSelect = paginationBarElement.querySelector(
+		'.publisher-profile-apps-page-size'
+	);
+	const paginationElement = paginationBarElement.querySelector(
+		'.publisher-profile-apps-pagination'
+	);
+	const resultsRangeElement = paginationBarElement.querySelector(
+		'.publisher-profile-apps-results-range'
+	);
+	const resultsTotalElement = paginationBarElement.querySelector(
+		'.publisher-profile-apps-results-total'
+	);
+
+	const spritemap = paginationElement.dataset.spritemap;
+
+	let currentPageNumber = 1;
+
+	const addPageItem = (content, pageNumber, disabled, active) => {
+		const pageItem = document.createElement('li');
+
+		pageItem.classList.add('page-item');
+
+		if (active) {
+			pageItem.classList.add('active');
+		}
+
+		if (disabled) {
+			pageItem.classList.add('disabled');
+		}
+
+		const pageLink = document.createElement('button');
+
+		pageLink.classList.add('page-link');
+		pageLink.disabled = disabled;
+		pageLink.type = 'button';
+
+		if (typeof content === 'number') {
+			pageLink.textContent = content;
+		}
+		else {
+			pageLink.innerHTML = `<svg class="lexicon-icon" role="presentation"><use href="${spritemap}#${content}" /></svg>`;
+		}
+
+		if (pageNumber) {
+			pageLink.addEventListener('click', () => {
+				currentPageNumber = pageNumber;
+
+				showPage();
+			});
+		}
+
+		pageItem.appendChild(pageLink);
+
+		paginationElement.appendChild(pageItem);
+	};
+
+	const showPage = () => {
+		const pageSize = parseInt(pageSizeSelect.value, 10);
+
+		const pagesCount = Math.max(Math.ceil(appCards.length / pageSize), 1);
+
+		currentPageNumber = Math.min(currentPageNumber, pagesCount);
+
+		appCards.forEach((appCard, index) => {
+			appCard.classList.toggle(
+				'publisher-profile-app-card-hidden',
+				Math.floor(index / pageSize) !== currentPageNumber - 1
+			);
+		});
+
+		resultsRangeElement.textContent = resultsRangeElement.dataset.template
+			.replace('{0}', (currentPageNumber - 1) * pageSize + 1)
+			.replace(
+				'{1}',
+				Math.min(currentPageNumber * pageSize, appCards.length)
+			);
+
+		resultsTotalElement.textContent =
+			resultsTotalElement.dataset.template.replace(
+				'{0}',
+				appCards.length
+			);
+
+		paginationElement.innerHTML = '';
+
+		addPageItem('angle-left', currentPageNumber - 1, currentPageNumber === 1, false);
+
+		let previousPageNumberShown = 0;
+
+		for (let pageNumber = 1; pageNumber <= pagesCount; pageNumber++) {
+			if (
+				(pageNumber !== 1) &&
+				(pageNumber !== pagesCount) &&
+				(Math.abs(pageNumber - currentPageNumber) > 2)
+			) {
+				continue;
+			}
+
+			if (pageNumber - previousPageNumberShown > 1) {
+				addPageItem('ellipsis-h', 0, true, false);
+			}
+
+			addPageItem(
+				pageNumber,
+				pageNumber,
+				false,
+				pageNumber === currentPageNumber
+			);
+
+			previousPageNumberShown = pageNumber;
+		}
+
+		addPageItem(
+			'angle-right',
+			currentPageNumber + 1,
+			currentPageNumber === pagesCount,
+			false
+		);
+	};
+
+	pageSizeSelect.addEventListener('change', () => {
+		currentPageNumber = 1;
+
+		showPage();
+	});
+
+	showPage();
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-details/fragment.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-details/fragment.json
@@ -1,0 +1,8 @@
+{
+	"cssPath": "index.css",
+	"htmlPath": "index.html",
+	"icon": "info-circle",
+	"jsPath": "index.js",
+	"name": "Publisher Profile Details",
+	"type": "component"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-details/index.css
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-details/index.css
@@ -1,0 +1,31 @@
+.publisher-profile-details {
+	border: 1px solid #e2e2e4;
+	border-radius: 10px;
+	padding: 8px 16px;
+}
+
+.publisher-profile-details .lexicon-icon {
+	color: #54555f;
+	height: 16px;
+	margin-top: 0;
+	width: 16px;
+}
+
+.publisher-profile-details .publisher-profile-details-label {
+	color: #282934;
+	font-size: 13px;
+	font-weight: 600;
+	letter-spacing: 0.02em;
+	line-height: 16px;
+	margin-bottom: 12px;
+	text-transform: uppercase;
+}
+
+.publisher-profile-details .publisher-profile-details-section {
+	border-bottom: 1px solid #e2e2e4;
+	padding: 16px 0;
+}
+
+.publisher-profile-details .publisher-profile-details-section:last-child {
+	border-bottom: 0;
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-details/index.html
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-details/index.html
@@ -1,0 +1,58 @@
+[#assign
+	email = ""
+	location = ""
+	websiteURL = ""
+/]
+
+[#assign infoItem = request.getAttribute("INFO_ITEM")! /]
+
+[#if infoItem?has_content]
+	[#attempt]
+		[#assign values = infoItem.getValues() /]
+
+		[#assign
+			email = (values["email"])!""
+			location = (values["location"])!""
+			websiteURL = (values["websiteURL"])!""
+		/]
+	[#recover]
+	[/#attempt]
+[/#if]
+
+<div class="publisher-profile-details">
+	[#if websiteURL?has_content]
+		<div class="publisher-profile-details-section">
+			<div class="publisher-profile-details-label">${languageUtil.get(locale, "website", "Website")}</div>
+
+			<div class="align-items-center d-flex">
+				[@clay["icon"] symbol="globe" /]
+
+				<a class="ml-2" href="${websiteURL}" target="_blank">${websiteURL?replace("https://", "")?replace("http://", "")}</a>
+			</div>
+		</div>
+	[/#if]
+
+	[#if email?has_content]
+		<div class="publisher-profile-details-section">
+			<div class="publisher-profile-details-label">${languageUtil.get(locale, "mail", "Mail")}</div>
+
+			<div class="align-items-center d-flex">
+				[@clay["icon"] symbol="envelope-closed" /]
+
+				<a class="ml-2" href="mailto:${email}">${email}</a>
+			</div>
+		</div>
+	[/#if]
+
+	[#if location?has_content]
+		<div class="publisher-profile-details-section">
+			<div class="publisher-profile-details-label">${languageUtil.get(locale, "location", "Location")}</div>
+
+			<div class="d-flex">
+				[@clay["icon"] symbol="geolocation" /]
+
+				<span class="ml-2">${location}</span>
+			</div>
+		</div>
+	[/#if]
+</div>

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-details/index.js
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-details/index.js
@@ -1,0 +1,4 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-header/configuration.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-header/configuration.json
@@ -13,13 +13,6 @@
 					"label": "Hide Rating Info",
 					"name": "hideRatingInfo",
 					"type": "checkbox"
-				},
-				{
-					"dataType": "int",
-					"defaultValue": "8",
-					"label": "Page Size",
-					"name": "pageSize",
-					"type": "text"
 				}
 			]
 		}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-header/fragment.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-header/fragment.json
@@ -1,0 +1,9 @@
+{
+	"configurationPath": "configuration.json",
+	"cssPath": "index.css",
+	"htmlPath": "index.html",
+	"icon": "user",
+	"jsPath": "index.js",
+	"name": "Publisher Profile Header",
+	"type": "component"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-header/index.css
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-header/index.css
@@ -1,0 +1,26 @@
+.publisher-profile-header .publisher-profile-header-avatar {
+	border-radius: 50%;
+	height: 72px;
+	overflow: hidden;
+	width: 72px;
+}
+
+.publisher-profile-header .publisher-profile-header-image {
+	object-fit: contain;
+}
+
+.publisher-profile-header .publisher-profile-header-name {
+	font-size: 28px;
+	font-weight: 700;
+	line-height: 36px;
+}
+
+.publisher-profile-header .publisher-profile-header-stats {
+	color: #54555f;
+	font-size: 13px;
+	line-height: 16px;
+}
+
+.publisher-profile-header .stars {
+	color: var(--color-accent-6);
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-header/index.html
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-header/index.html
@@ -1,0 +1,106 @@
+[#assign
+	email = ""
+	publisherName = ""
+	publisherProfileImageURL = ""
+	showContactForm = false
+/]
+
+[#assign infoItem = request.getAttribute("INFO_ITEM")! /]
+
+[#if infoItem?has_content]
+	[#attempt]
+		[#assign values = infoItem.getValues() /]
+
+		[#assign
+			email = (values["email"])!""
+			publisherName = (values["publisherName"])!""
+			publisherProfileImageURL = (values["publisherProfileImageURL"])!""
+			showContactForm = (values["showContactForm"])!false
+		/]
+	[#recover]
+	[/#attempt]
+[/#if]
+
+[#assign channelId = "" /]
+
+[#if configuration.channelId?has_content]
+	[#assign channelId = configuration.channelId /]
+[#else]
+	[#attempt]
+		[#assign channel = restClient.get("/headless-commerce-delivery-catalog/v1.0/channels") /]
+
+		[#if channel?has_content && (channel.items)?has_content]
+			[#assign siteChannels = channel.items?filter(siteChannel -> siteChannel.siteGroupId == themeDisplay.getSiteGroupId()) /]
+
+			[#if siteChannels?has_content]
+				[#assign channelId = siteChannels[0].id /]
+			[/#if]
+		[/#if]
+	[#recover]
+	[/#attempt]
+[/#if]
+
+[#function getPublisherName product]
+	[#if product.productSpecifications?has_content]
+		[#local specification = product.productSpecifications?filter(productSpecification ->
+			stringUtil.equals(productSpecification.specificationKey, "publisher-name")) /]
+
+		[#if specification?has_content]
+			[#return specification?first.value!"" /]
+		[/#if]
+	[/#if]
+
+	[#return "" /]
+[/#function]
+
+[#assign appsCount = 0 /]
+
+[#if publisherName?has_content && channelId?has_content]
+	[#attempt]
+		[#assign response = restClient.get("/headless-commerce-delivery-catalog/v1.0/channels/${channelId}/products?accountId=-1&nestedFields=productSpecifications&pageSize=100") /]
+
+		[#assign appsCount = ((response.items![])?filter(product -> getPublisherName(product) == publisherName))?size /]
+	[#recover]
+	[/#attempt]
+[/#if]
+
+<div class="publisher-profile-header">
+	<div class="align-items-center d-flex flex-wrap justify-content-between">
+		<div class="align-items-center d-flex">
+			[#if publisherProfileImageURL?has_content]
+				<div class="align-items-center bg-white d-flex image-container justify-content-center mr-3 publisher-profile-header-avatar">
+					<img alt="${publisherName}" class="publisher-profile-header-image" draggable="false" height="48" src="${(publisherProfileImageURL?replace('https://', 'http://'))?js_string}" width="48" />
+				</div>
+			[/#if]
+
+			<div class="d-flex flex-column">
+				<h1 class="mb-1 publisher-profile-header-name">${publisherName}</h1>
+
+				<div class="align-items-center d-flex publisher-profile-header-stats">
+					<span>${appsCount} ${languageUtil.get(locale, "apps", "Apps")}</span>
+
+					[#if configuration.hideRatingInfo == false]
+						<span class="mx-2">&bull;</span>
+
+						<span class="stars">
+							[@clay["icon"] symbol="star" /]
+						</span>
+						<span class="ml-1">4.9 ${languageUtil.get(locale, "average-rating", "Average Rating")}</span>
+
+						<span class="mx-2">&bull;</span>
+
+						[@clay["icon"] symbol="download" /]
+
+						<span class="ml-1">8.5k ${languageUtil.get(locale, "total-download", "Total Download")}</span>
+					[/#if]
+				</div>
+			</div>
+		</div>
+
+		[#if showContactForm && email?has_content]
+			<a class="btn btn-primary publisher-profile-header-contact" href="mailto:${email}">
+				${languageUtil.get(locale, "contact", "Contact")}
+			</a>
+		[/#if]
+	</div>
+</div>

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-header/index.js
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/fragments/group/liferay-one/fragments/publisher-profile-header/index.js
@@ -1,0 +1,4 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/layout-page-templates/display-page-templates/publisher-profile/page-definition.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/layout-page-templates/display-page-templates/publisher-profile/page-definition.json
@@ -4,111 +4,20 @@
 			{
 				"definition": {
 					"fragmentStyle": {
-						"paddingBottom": "6",
-						"paddingTop": "6"
+						"backgroundColor": "whiteColor",
+						"borderWidth": "0",
+						"minHeight": "100vh"
 					},
 					"indexed": true,
 					"layout": {
-						"widthType": "Fixed"
 					}
 				},
 				"pageElements": [
 					{
 						"definition": {
-							"fragmentStyle": {
-								"borderWidth": "0",
-								"paddingBottom": "4"
-							},
-							"indexed": true,
-							"layout": {
-								"align": "middle",
-								"contentDisplay": "FlexRow"
-							}
-						},
-						"pageElements": [
-							{
-								"definition": {
-									"customCSS": ".[$FRAGMENT_CLASS$] img {\n\tborder-radius: 50%;\n\theight: 96px;\n\tobject-fit: cover;\n\twidth: 96px;\n}",
-									"fragment": {
-										"key": "BASIC_COMPONENT-image"
-									},
-									"fragmentConfig": {
-										"imageSize": "w-100"
-									},
-									"fragmentFields": [
-										{
-											"id": "image-square",
-											"value": {
-												"fragmentImage": {
-													"url": {
-														"mapping": {
-															"fieldKey": "publisherProfileImageURL",
-															"itemReference": {
-																"contextSource": "DisplayPageItem"
-															}
-														}
-													}
-												}
-											}
-										}
-									],
-									"fragmentStyle": {
-										"height": "96px",
-										"marginRight": "4",
-										"maxWidth": "96px",
-										"width": "96px"
-									},
-									"indexed": true
-								},
-								"type": "Fragment"
-							},
-							{
-								"definition": {
-									"fragment": {
-										"key": "BASIC_COMPONENT-heading"
-									},
-									"fragmentConfig": {
-										"headingLevel": "h1"
-									},
-									"fragmentFields": [
-										{
-											"id": "element-text",
-											"value": {
-												"fragmentLink": {
-												},
-												"text": {
-													"mapping": {
-														"fieldKey": "publisherName",
-														"itemReference": {
-															"contextSource": "DisplayPageItem"
-														}
-													}
-												}
-											}
-										}
-									],
-									"fragmentStyle": {
-										"marginBottom": "0"
-									},
-									"indexed": true
-								},
-								"type": "Fragment"
-							}
-						],
-						"type": "Section"
-					},
-					{
-						"definition": {
-							"fragmentStyle": {
-								"borderColor": "#E2E2E4",
-								"borderRadius": "8px",
-								"borderWidth": "1",
-								"marginBottom": "4",
-								"paddingBottom": "4",
-								"paddingLeft": "4",
-								"paddingRight": "4",
-								"paddingTop": "4"
-							},
+							"cssClasses": [
+								"bg-neutral-1"
+							],
 							"indexed": true,
 							"layout": {
 							}
@@ -116,58 +25,30 @@
 						"pageElements": [
 							{
 								"definition": {
-									"fragment": {
-										"key": "BASIC_COMPONENT-heading"
-									},
-									"fragmentConfig": {
-										"headingLevel": "h4"
-									},
-									"fragmentFields": [
-										{
-											"id": "element-text",
-											"value": {
-												"fragmentLink": {
-												},
-												"text": {
-													"value_i18n": {
-														"en_US": "About"
-													}
-												}
-											}
-										}
-									],
 									"fragmentStyle": {
-										"marginBottom": "3"
+										"paddingBottom": "5",
+										"paddingTop": "5"
 									},
-									"indexed": true
+									"indexed": true,
+									"layout": {
+										"widthType": "Fixed"
+									}
 								},
-								"type": "Fragment"
-							},
-							{
-								"definition": {
-									"fragment": {
-										"key": "BASIC_COMPONENT-html"
-									},
-									"fragmentConfig": {
-									},
-									"fragmentFields": [
-										{
-											"id": "element-html",
-											"value": {
-												"html": {
-													"mapping": {
-														"fieldKey": "description",
-														"itemReference": {
-															"contextSource": "DisplayPageItem"
-														}
-													}
-												}
-											}
-										}
-									],
-									"indexed": true
-								},
-								"type": "Fragment"
+								"pageElements": [
+									{
+										"definition": {
+											"fragment": {
+												"key": "publisher-profile-header",
+												"siteKey": "[$GROUP_KEY$]"
+											},
+											"fragmentConfig": {
+											},
+											"indexed": true
+										},
+										"type": "Fragment"
+									}
+								],
+								"type": "Section"
 							}
 						],
 						"type": "Section"
@@ -175,368 +56,198 @@
 					{
 						"definition": {
 							"fragmentStyle": {
-								"borderColor": "#E2E2E4",
-								"borderRadius": "8px",
-								"borderWidth": "1",
-								"marginBottom": "4",
-								"paddingBottom": "4",
-								"paddingLeft": "4",
-								"paddingRight": "4",
-								"paddingTop": "4"
+								"borderWidth": "0"
 							},
 							"indexed": true,
 							"layout": {
+								"widthType": "Fixed"
 							}
 						},
 						"pageElements": [
 							{
 								"definition": {
-									"fragment": {
-										"key": "BASIC_COMPONENT-heading"
+									"fragmentStyle": {
+										"borderWidth": "0",
+										"paddingBottom": "6",
+										"paddingTop": "6"
 									},
-									"fragmentConfig": {
-										"headingLevel": "h4"
-									},
-									"fragmentFields": [
-										{
-											"id": "element-text",
-											"value": {
-												"fragmentLink": {
+									"indexed": true,
+									"layout": {
+										"paddingBottom": 6,
+										"paddingTop": 6
+									}
+								},
+								"pageElements": [
+									{
+										"definition": {
+											"gutters": true,
+											"indexed": true,
+											"modulesPerRow": 2,
+											"numberOfColumns": 2,
+											"reverseOrder": false,
+											"rowViewports": [
+												{
+													"id": "landscapeMobile",
+													"rowViewportDefinition": {
+													}
 												},
-												"text": {
-													"value_i18n": {
-														"en_US": "Contact"
+												{
+													"id": "portraitMobile",
+													"rowViewportDefinition": {
+														"modulesPerRow": 1
+													}
+												},
+												{
+													"id": "tablet",
+													"rowViewportDefinition": {
 													}
 												}
-											}
-										}
-									],
-									"fragmentStyle": {
-										"marginBottom": "3"
-									},
-									"indexed": true
-								},
-								"type": "Fragment"
-							},
-							{
-								"definition": {
-									"fragment": {
-										"key": "BASIC_COMPONENT-heading"
-									},
-									"fragmentConfig": {
-										"headingLevel": "h6"
-									},
-									"fragmentFields": [
-										{
-											"id": "element-text",
-											"value": {
-												"fragmentLink": {
-												},
-												"text": {
-													"value_i18n": {
-														"en_US": "Email"
-													}
-												}
-											}
-										}
-									],
-									"fragmentStyle": {
-										"marginBottom": "0",
-										"textColor": "colorNeutral6"
-									},
-									"indexed": true
-								},
-								"type": "Fragment"
-							},
-							{
-								"definition": {
-									"fragment": {
-										"key": "BASIC_COMPONENT-paragraph"
-									},
-									"fragmentConfig": {
-									},
-									"fragmentFields": [
-										{
-											"id": "element-text",
-											"value": {
-												"fragmentLink": {
-												},
-												"text": {
-													"mapping": {
-														"fieldKey": "email",
-														"itemReference": {
-															"contextSource": "DisplayPageItem"
+											],
+											"verticalAlignment": "top"
+										},
+										"pageElements": [
+											{
+												"definition": {
+													"columnViewports": [
+														{
+															"columnViewportDefinition": {
+															},
+															"id": "landscapeMobile"
+														},
+														{
+															"columnViewportDefinition": {
+																"size": 12
+															},
+															"id": "portraitMobile"
+														},
+														{
+															"columnViewportDefinition": {
+															},
+															"id": "tablet"
 														}
-													}
-												}
-											}
-										}
-									],
-									"fragmentStyle": {
-										"marginBottom": "3"
-									},
-									"indexed": true
-								},
-								"type": "Fragment"
-							},
-							{
-								"definition": {
-									"fragment": {
-										"key": "BASIC_COMPONENT-heading"
-									},
-									"fragmentConfig": {
-										"headingLevel": "h6"
-									},
-									"fragmentFields": [
-										{
-											"id": "element-text",
-											"value": {
-												"fragmentLink": {
+													],
+													"size": 8
 												},
-												"text": {
-													"value_i18n": {
-														"en_US": "Support Email"
+												"pageElements": [
+													{
+														"definition": {
+															"fragment": {
+																"key": "BASIC_COMPONENT-heading"
+															},
+															"fragmentConfig": {
+																"headingLevel": "h4"
+															},
+															"fragmentFields": [
+																{
+																	"id": "element-text",
+																	"value": {
+																		"fragmentLink": {
+																		},
+																		"text": {
+																			"value_i18n": {
+																				"en_US": "About Us"
+																			}
+																		}
+																	}
+																}
+															],
+															"fragmentStyle": {
+																"marginBottom": "3"
+															},
+															"indexed": true
+														},
+														"type": "Fragment"
+													},
+													{
+														"definition": {
+															"fragment": {
+																"key": "BASIC_COMPONENT-html"
+															},
+															"fragmentConfig": {
+															},
+															"fragmentFields": [
+																{
+																	"id": "element-html",
+																	"value": {
+																		"html": {
+																			"mapping": {
+																				"fieldKey": "description",
+																				"itemReference": {
+																					"contextSource": "DisplayPageItem"
+																				}
+																			}
+																		}
+																	}
+																}
+															],
+															"fragmentStyle": {
+																"marginBottom": "5"
+															},
+															"indexed": true
+														},
+														"type": "Fragment"
+													},
+													{
+														"definition": {
+															"fragment": {
+																"key": "publisher-profile-apps",
+																"siteKey": "[$GROUP_KEY$]"
+															},
+															"fragmentConfig": {
+															},
+															"indexed": true
+														},
+														"type": "Fragment"
 													}
-												}
-											}
-										}
-									],
-									"fragmentStyle": {
-										"marginBottom": "0",
-										"textColor": "colorNeutral6"
-									},
-									"indexed": true
-								},
-								"type": "Fragment"
-							},
-							{
-								"definition": {
-									"fragment": {
-										"key": "BASIC_COMPONENT-paragraph"
-									},
-									"fragmentConfig": {
-									},
-									"fragmentFields": [
-										{
-											"id": "element-text",
-											"value": {
-												"fragmentLink": {
-												},
-												"text": {
-													"mapping": {
-														"fieldKey": "supportEmail",
-														"itemReference": {
-															"contextSource": "DisplayPageItem"
+												],
+												"type": "Column"
+											},
+											{
+												"definition": {
+													"columnViewports": [
+														{
+															"columnViewportDefinition": {
+															},
+															"id": "landscapeMobile"
+														},
+														{
+															"columnViewportDefinition": {
+																"size": 12
+															},
+															"id": "portraitMobile"
+														},
+														{
+															"columnViewportDefinition": {
+															},
+															"id": "tablet"
 														}
-													}
-												}
-											}
-										}
-									],
-									"fragmentStyle": {
-										"marginBottom": "3"
-									},
-									"indexed": true
-								},
-								"type": "Fragment"
-							},
-							{
-								"definition": {
-									"fragment": {
-										"key": "BASIC_COMPONENT-heading"
-									},
-									"fragmentConfig": {
-										"headingLevel": "h6"
-									},
-									"fragmentFields": [
-										{
-											"id": "element-text",
-											"value": {
-												"fragmentLink": {
+													],
+													"size": 4
 												},
-												"text": {
-													"value_i18n": {
-														"en_US": "Sales Email"
+												"pageElements": [
+													{
+														"definition": {
+															"fragment": {
+																"key": "publisher-profile-details",
+																"siteKey": "[$GROUP_KEY$]"
+															},
+															"fragmentConfig": {
+															},
+															"indexed": true
+														},
+														"type": "Fragment"
 													}
-												}
+												],
+												"type": "Column"
 											}
-										}
-									],
-									"fragmentStyle": {
-										"marginBottom": "0",
-										"textColor": "colorNeutral6"
-									},
-									"indexed": true
-								},
-								"type": "Fragment"
-							},
-							{
-								"definition": {
-									"fragment": {
-										"key": "BASIC_COMPONENT-paragraph"
-									},
-									"fragmentConfig": {
-									},
-									"fragmentFields": [
-										{
-											"id": "element-text",
-											"value": {
-												"fragmentLink": {
-												},
-												"text": {
-													"mapping": {
-														"fieldKey": "salesEmail",
-														"itemReference": {
-															"contextSource": "DisplayPageItem"
-														}
-													}
-												}
-											}
-										}
-									],
-									"fragmentStyle": {
-										"marginBottom": "3"
-									},
-									"indexed": true
-								},
-								"type": "Fragment"
-							},
-							{
-								"definition": {
-									"fragment": {
-										"key": "BASIC_COMPONENT-heading"
-									},
-									"fragmentConfig": {
-										"headingLevel": "h6"
-									},
-									"fragmentFields": [
-										{
-											"id": "element-text",
-											"value": {
-												"fragmentLink": {
-												},
-												"text": {
-													"value_i18n": {
-														"en_US": "Website"
-													}
-												}
-											}
-										}
-									],
-									"fragmentStyle": {
-										"marginBottom": "0",
-										"textColor": "colorNeutral6"
-									},
-									"indexed": true
-								},
-								"type": "Fragment"
-							},
-							{
-								"definition": {
-									"fragment": {
-										"key": "BASIC_COMPONENT-paragraph"
-									},
-									"fragmentConfig": {
-									},
-									"fragmentFields": [
-										{
-											"id": "element-text",
-											"value": {
-												"fragmentLink": {
-												},
-												"text": {
-													"mapping": {
-														"fieldKey": "websiteURL",
-														"itemReference": {
-															"contextSource": "DisplayPageItem"
-														}
-													}
-												}
-											}
-										}
-									],
-									"fragmentStyle": {
-										"marginBottom": "3"
-									},
-									"indexed": true
-								},
-								"type": "Fragment"
-							},
-							{
-								"definition": {
-									"fragment": {
-										"key": "BASIC_COMPONENT-heading"
-									},
-									"fragmentConfig": {
-										"headingLevel": "h6"
-									},
-									"fragmentFields": [
-										{
-											"id": "element-text",
-											"value": {
-												"fragmentLink": {
-												},
-												"text": {
-													"value_i18n": {
-														"en_US": "Location"
-													}
-												}
-											}
-										}
-									],
-									"fragmentStyle": {
-										"marginBottom": "0",
-										"textColor": "colorNeutral6"
-									},
-									"indexed": true
-								},
-								"type": "Fragment"
-							},
-							{
-								"definition": {
-									"fragment": {
-										"key": "BASIC_COMPONENT-paragraph"
-									},
-									"fragmentConfig": {
-									},
-									"fragmentFields": [
-										{
-											"id": "element-text",
-											"value": {
-												"fragmentLink": {
-												},
-												"text": {
-													"mapping": {
-														"fieldKey": "location",
-														"itemReference": {
-															"contextSource": "DisplayPageItem"
-														}
-													}
-												}
-											}
-										}
-									],
-									"fragmentStyle": {
-										"marginBottom": "0"
-									},
-									"indexed": true
-								},
-								"type": "Fragment"
+										],
+										"type": "Row"
+									}
+								],
+								"type": "Section"
 							}
 						],
 						"type": "Section"
-					},
-					{
-						"definition": {
-							"fragment": {
-								"key": "publisher-profile-apps",
-								"siteKey": "[$GROUP_KEY$]"
-							},
-							"fragmentConfig": {
-							},
-							"indexed": true
-						},
-						"type": "Fragment"
 					}
 				],
 				"type": "Section"

--- a/workspaces/liferay-one-workspace/scripts/bootstrap.sh
+++ b/workspaces/liferay-one-workspace/scripts/bootstrap.sh
@@ -75,6 +75,9 @@ function main {
 	echo "Setting virtual hosts."
 	bash scripts/bootstrap/set_virtual_hosts.sh
 
+	echo "Re-provisioning etc-spring-boot OAuth redirect URIs."
+	bash scripts/bootstrap/reprovision_etc_spring_boot_oauth.sh
+
 	echo "Done. Liferay is running at http://localhost."
 }
 

--- a/workspaces/liferay-one-workspace/scripts/bootstrap/reprovision_etc_spring_boot_oauth.sh
+++ b/workspaces/liferay-one-workspace/scripts/bootstrap/reprovision_etc_spring_boot_oauth.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+source ../_common.sh
+
+# Re-provision the liferay-one-etc-spring-boot OAuth applications so their
+# redirect URIs pick up virtual hosts that were bound after the client extension
+# was first deployed, and restart the Spring Boot sidecar so it re-reads the
+# refreshed route configuration.
+#
+# The user-agent application (liferay-one-etc-spring-boot-oaua) derives its
+# redirect URIs from the company's virtual hosts at provision time, in
+# OAuth2ProviderApplicationUserAgentConfigurationFactory.doActivate. The hostname
+# is captured literally there -- only the protocol and port are interpolated at
+# runtime -- so a host bound afterward never appears in the stored redirect URIs.
+# During bootstrap the client extension is provisioned before set_virtual_hosts.sh
+# binds one.localhost to the One site, so the application is created with only the
+# localhost redirect URI. Browsing the site at its domain root then fails the
+# SPA's Liferay.OAuth2.FromUserAgentApplication lookup with "No redirectURI
+# matching origin http://one.localhost:8080".
+#
+# Redeploying the client extension re-fires the configuration factories, which
+# re-read getVirtualHosts(companyId) -- now including one.localhost -- update the
+# applications' redirect URIs in place through the service layer (the client id
+# and secret are reused), and rewrite the OAuth route files on the shared routes
+# volume. --rerun-tasks is required: without it Gradle treats
+# createClientExtensionConfig as up to date and reuses the previous build
+# timestamp, the redeployed config is byte-identical, and the config bundle
+# tracker never re-activates the factories.
+#
+# The Spring Boot sidecar builds its OAuth client registrations once, from the
+# route files, at startup -- wait-for-routes.sh only gates on the DXP route, not
+# on the etc-spring-boot routes, so a sidecar that started before its routes were
+# written comes up without the liferay-one-etc-spring-boot-oahs registration and
+# every server-to-server call fails with "Could not find ClientRegistration".
+# docker compose up --detach is a no-op when the image is unchanged, so restart
+# the sidecar explicitly here to force it to re-read the routes.
+#
+# Run this after set_virtual_hosts.sh from every orchestrator that binds a
+# virtual host: bootstrap.sh, instance_reset.sh, and site_reset.sh.
+
+CONTAINER_NAME="liferay"
+
+SIDECAR_SERVICE="liferay-one-etc-spring-boot"
+
+SIDECAR_READY_URL="http://localhost:58081/ready"
+
+function main {
+	cd ../..
+
+	local container_id
+
+	container_id="$(docker ps --quiet --filter "name=^${CONTAINER_NAME}$")"
+
+	if [[ -z ${container_id} ]]
+	then
+		echo "Unable to find a running \"${CONTAINER_NAME}\" container." >&2
+
+		return 1
+	fi
+
+	./gradlew ":client-extensions:${SIDECAR_SERVICE}:deploy" \
+		-Ddeploy.docker.container.id="${container_id}" \
+		--rerun-tasks
+
+	# The portal writes the route files asynchronously after the bundle is
+	# deployed, so give the configuration factories a moment to run before the
+	# sidecar re-reads them.
+
+	echo "Waiting for the routes to settle."
+
+	sleep 15
+
+	echo "Restarting the Spring Boot client extension container."
+
+	docker compose restart "${SIDECAR_SERVICE}"
+
+	echo "Waiting for the Spring Boot client extension to be ready."
+
+	local elapsed=0
+
+	until curl --fail --max-time 5 --output /dev/null --silent "${SIDECAR_READY_URL}"
+	do
+		if [ "${elapsed}" -ge 120 ]
+		then
+			echo "Timed out waiting for the Spring Boot client extension." >&2
+
+			return 1
+		fi
+
+		printf '.'
+
+		sleep 3
+
+		elapsed=$((elapsed + 3))
+	done
+
+	echo " The Spring Boot client extension is ready."
+}
+
+main "${@}"

--- a/workspaces/liferay-one-workspace/scripts/instance_reset.sh
+++ b/workspaces/liferay-one-workspace/scripts/instance_reset.sh
@@ -78,6 +78,9 @@ function main {
 	echo "Setting virtual hosts."
 	bash scripts/bootstrap/set_virtual_hosts.sh
 
+	echo "Re-provisioning etc-spring-boot OAuth redirect URIs."
+	bash scripts/bootstrap/reprovision_etc_spring_boot_oauth.sh
+
 	echo "Done. The Liferay instance data has been reset."
 }
 

--- a/workspaces/liferay-one-workspace/scripts/site_reset.sh
+++ b/workspaces/liferay-one-workspace/scripts/site_reset.sh
@@ -61,6 +61,9 @@ function main {
 	echo "Setting virtual hosts."
 	bash scripts/bootstrap/set_virtual_hosts.sh
 
+	echo "Re-provisioning etc-spring-boot OAuth redirect URIs."
+	bash scripts/bootstrap/reprovision_etc_spring_boot_oauth.sh
+
 	echo "Done. The One site has been reset."
 }
 


### PR DESCRIPTION
Rebuilds the publisher profile display page per the Figma MP Storefront Redesign (node 1232-34641), based on the legacy marketplace `PUBLISHER-DETAILS` object.

## What this delivers

- **Header band**: publisher identity, live apps count, and a Contact button gated by `showContactForm`.
- **Two column body**: About Us and a paginated rich apps list (8 per page) beside the contact details panel.
- **Rich app cards** ported from `home-apps-display`: category badge, product icon, developer name, description, price model, and category tags.
- **Details panel** maps only fields that exist on the legacy object — Website, Mail, and Location. The phone row is gone (`phone` does not exist on `PUBLISHER-DETAILS`).
- **Reset scripts** now reprovision the etc-spring-boot OAuth applications after virtual hosts are bound, so redirect URIs include `one.localhost` and the sidecar reloads its client registrations.

## Root cause fixed along the way

The display page template used to import empty (404 on the friendly URL): fragment configuration checkbox fields declared `"dataType": "bool"`, which the fragment configuration schema rejects. The fragments then imported as drafts, and referencing a draft fragment makes the display page template import silently discard every page element and skip the default template flag.

## Validation

- Full `bootstrap.sh --reset`: all three publisher fragments import approved, the DPT imports with `defaultTemplate=true` and all fragment links, and `/web/one/c_publisherdetails/liferay-inc.` renders end-to-end.
- Screenshot matches the Figma layout (header, About Us, apps grid with badges/tags/pagination, Website/Mail/Location panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
