### PR TITLE
LPD-97785 LPD-97786 Fix LDP provisioning identity and subscription

### DIFF
--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/constants/MarketplaceConstants.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/constants/MarketplaceConstants.java
@@ -12,6 +12,13 @@ import java.util.Objects;
  */
 public class MarketplaceConstants {
 
+	public static final String ANALYTICS_LDP_ENTERPRISE_PRODUCT_ENTRY_ID =
+		"KOR-17350391";
+
+	public static final int ANALYTICS_OFFERING_ENTRY_STATUS_ACTIVE = 1;
+
+	public static final int ANALYTICS_OFFERING_ENTRY_STATUS_INACTIVE = 0;
+
 	public static final String[] KORONEIKI_AC_ENTITLEMENTS = {
 		"Liferay Analytics Cloud"
 	};

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/AnalyticsService.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/AnalyticsService.java
@@ -126,6 +126,10 @@ public class AnalyticsService extends BaseService {
 		}
 
 		try {
+			if (_log.isInfoEnabled()) {
+				_log.info("Provisioning Analytics Cloud project " + jsonObject);
+			}
+
 			String response = WebClient.builder(
 			).baseUrl(
 				analyticsContextJSONObject.getString("url")

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/AnalyticsService.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/AnalyticsService.java
@@ -14,6 +14,7 @@ import java.util.Objects;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -117,6 +118,13 @@ public class AnalyticsService extends BaseService {
 			JSONObject analyticsContextJSONObject, JSONObject jsonObject)
 		throws Exception {
 
+		JSONArray offeringEntriesJSONArray = jsonObject.optJSONArray(
+			"offeringEntries");
+
+		if (offeringEntriesJSONArray == null) {
+			offeringEntriesJSONArray = new JSONArray();
+		}
+
 		try {
 			String response = WebClient.builder(
 			).baseUrl(
@@ -149,7 +157,7 @@ public class AnalyticsService extends BaseService {
 				).with(
 					"name", jsonObject.getString("name")
 				).with(
-					"offeringEntries", "[]"
+					"offeringEntries", offeringEntriesJSONArray.toString()
 				).with(
 					"serverLocation", jsonObject.getString("serverLocation")
 				).with(

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/ProvisioningHubService.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/ProvisioningHubService.java
@@ -17,6 +17,7 @@ import com.liferay.osb.koroneiki.phloem.rest.client.dto.v1_0.Product;
 import com.liferay.osb.koroneiki.phloem.rest.client.dto.v1_0.ProductPurchase;
 import com.liferay.osb.koroneiki.phloem.rest.client.pagination.Page;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Validator;
@@ -232,6 +233,15 @@ public class ProvisioningHubService extends BaseService {
 		return MarketplaceConstants.ANALYTICS_OFFERING_ENTRY_STATUS_INACTIVE;
 	}
 
+	private String _getSalesforceProjectId(Account koroneikiAccount) {
+		if (ArrayUtil.isEmpty(koroneikiAccount.getExternalLinks())) {
+			return null;
+		}
+
+		return MarketplaceUtil.getEntityId(
+			koroneikiAccount.getExternalLinks(), "salesforce", "project");
+	}
+
 	private String _getServerLocation(String dataCenterLocation) {
 		if (Objects.equals(dataCenterLocation, "asia-south1")) {
 			return "asia-south1-ac5-c1";
@@ -417,6 +427,18 @@ public class ProvisioningHubService extends BaseService {
 			return;
 		}
 
+		String salesforceProjectId = _getSalesforceProjectId(koroneikiAccount);
+
+		if (Validator.isNull(salesforceProjectId)) {
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					"Missing the Salesforce project ID to provision LDP for " +
+						"account " + koroneikiAccount.getKey());
+			}
+
+			return;
+		}
+
 		String securityContactEmailAddress = properties.get(
 			"securityContactEmailAddress");
 
@@ -432,7 +454,7 @@ public class ProvisioningHubService extends BaseService {
 			).put(
 				"corpProjectName", koroneikiAccount.getName()
 			).put(
-				"corpProjectUuid", koroneikiAccount.getKey()
+				"corpProjectUuid", salesforceProjectId
 			).put(
 				"incidentReportEmailAddresses",
 				incidentReportEmailAddressesJSONArray
@@ -460,6 +482,8 @@ public class ProvisioningHubService extends BaseService {
 					order
 				).put(
 					"analyticsProject", new JSONObject(analyticsProject)
+				).put(
+					"salesforceProjectId", salesforceProjectId
 				).toString()
 			).build(),
 			order.getId(), order.getPaymentStatus());

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/ProvisioningHubService.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/ProvisioningHubService.java
@@ -17,11 +17,13 @@ import com.liferay.osb.koroneiki.phloem.rest.client.dto.v1_0.Product;
 import com.liferay.osb.koroneiki.phloem.rest.client.dto.v1_0.ProductPurchase;
 import com.liferay.osb.koroneiki.phloem.rest.client.pagination.Page;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.net.URL;
 
+import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
 
@@ -78,7 +80,7 @@ public class ProvisioningHubService extends BaseService {
 		}
 
 		if (productName.startsWith("Liferay Data Platform")) {
-			_provisionLDP(koroneikiAccount, order);
+			_provisionLDP(koroneikiAccount, order, productPurchase);
 		}
 	}
 
@@ -188,6 +190,46 @@ public class ProvisioningHubService extends BaseService {
 					"serverLocation",
 					_getServerLocation(properties.get("dataCenterLocation"))
 				)));
+	}
+
+	private JSONObject _getLDPOfferingEntryJSONObject(
+		ProductPurchase productPurchase) {
+
+		JSONObject offeringEntryJSONObject = new JSONObject(
+		).put(
+			"offeringEntryId", productPurchase.getKey()
+		).put(
+			"productEntryId",
+			MarketplaceConstants.ANALYTICS_LDP_ENTERPRISE_PRODUCT_ENTRY_ID
+		).put(
+			"quantity", GetterUtil.getInteger(productPurchase.getQuantity())
+		).put(
+			"status", _getOfferingEntryStatus(productPurchase)
+		);
+
+		Date startDate = productPurchase.getStartDate();
+
+		if (startDate != null) {
+			offeringEntryJSONObject.put("startDate", startDate.getTime());
+		}
+
+		Date endDate = productPurchase.getEndDate();
+
+		if (endDate != null) {
+			offeringEntryJSONObject.put("supportEndDate", endDate.getTime());
+		}
+
+		return offeringEntryJSONObject;
+	}
+
+	private int _getOfferingEntryStatus(ProductPurchase productPurchase) {
+		if (Objects.equals(
+				productPurchase.getStatus(), ProductPurchase.Status.APPROVED)) {
+
+			return MarketplaceConstants.ANALYTICS_OFFERING_ENTRY_STATUS_ACTIVE;
+		}
+
+		return MarketplaceConstants.ANALYTICS_OFFERING_ENTRY_STATUS_INACTIVE;
 	}
 
 	private String _getServerLocation(String dataCenterLocation) {
@@ -355,7 +397,9 @@ public class ProvisioningHubService extends BaseService {
 			MarketplaceConstants.ORDER_PAYMENT_STATUS_NOT_REQUIRED);
 	}
 
-	private void _provisionLDP(Account koroneikiAccount, Order order)
+	private void _provisionLDP(
+			Account koroneikiAccount, Order order,
+			ProductPurchase productPurchase)
 		throws Exception {
 
 		Map<String, String> properties = koroneikiAccount.getProperties();
@@ -394,6 +438,12 @@ public class ProvisioningHubService extends BaseService {
 				incidentReportEmailAddressesJSONArray
 			).put(
 				"name", properties.get("ldpWorkspaceName")
+			).put(
+				"offeringEntries",
+				new JSONArray(
+				).put(
+					_getLDPOfferingEntryJSONObject(productPurchase)
+				)
 			).put(
 				"ownerEmailAddress",
 				_getContactEmailAddress(

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/ProvisioningHubService.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/ProvisioningHubService.java
@@ -77,9 +77,7 @@ public class ProvisioningHubService extends BaseService {
 			return;
 		}
 
-		if (Objects.equals(
-				productName, "Liferay Data Platform (Private Beta)")) {
-
+		if (productName.startsWith("Liferay Data Platform")) {
 			_provisionLDP(koroneikiAccount, order);
 		}
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97785
https://liferay.atlassian.net/browse/LPD-97786

## What Is Being Fixed

Three defects sat on the leg of a Liferay Data Platform sale where the Marketplace asks Analytics Cloud to create the customer's workspace.

The product name gate matched the exact string `Liferay Data Platform (Private Beta)`. An order for the generally available product, or for `Liferay Data Platform Enterprise`, matched nothing and fell through the whole `provision` method — no Analytics Cloud call and no `completeOrder`, so the order sat in Pending with no exception and nothing in the log to notice.

The Analytics Cloud call hardcoded an empty `offeringEntries` list. Analytics Cloud rejects that payload outright when it runs with subscription push enabled, and ignores the field entirely when it runs with subscription push disabled, resolving the subscription from Koroneiki instead. Either way the workspace never carried the plan the customer bought: no subscription name, inactive, and every usage limit at zero.

The workspace was keyed by the Koroneiki account key, so every LDP that went live would have needed a later migration onto the Salesforce project ID.

## How It Is Being Fixed

The product name gate now matches the product family prefix, the same way the AI Hub branch immediately above it already does, so every Data Platform product reaches provisioning.

The offering entry is derived from the Koroneiki product purchase that triggered the order, and `AnalyticsService` reads `offeringEntries` from the payload instead of hardcoding it, defaulting to an empty array so the DSR flow that shares the method is unaffected. The field names and the epoch-millis dates were taken from Analytics Cloud's own deserializer rather than from documentation: `OSBOfferingEntry` is read with an `ObjectMapper` that exposes private fields and strips the leading underscore. The product entry ID is pinned to Liferay Data Platform Enterprise because Analytics Cloud validates it against its own product catalog, which holds no entry for the Koroneiki product key the LDP SKU carries; forwarding the purchased key would fail validation.

Provisioning then sends the Salesforce project ID as `corpProjectUuid` and records it in the order metadata, matching what AI Hub and SEO Studio already do. When the account carries no Salesforce project link the order is skipped rather than provisioned under an empty identifier. The request payload is now logged, so a workspace that comes back with an unexpected subscription can be traced to the payload that produced it.

Two things are worth flagging for whoever reviews this. The change depends on `osb.faro.subscription.push.enabled=true` on the Analytics Cloud side: with the flag off, Analytics Cloud ignores the offering entries and tries to resolve `corpProjectUuid` in Koroneiki, where a Salesforce project ID resolves to nothing. And the DSR path in the same class deliberately still keys its workspace by the Koroneiki account key — switching it would orphan the DSR workspaces already created under that key, so an account buying both DSR and LDP now ends up with two workspaces until that is migrated under its own ticket.

## Why Are There No Tests?

The module has no test infrastructure — no `src/testIntegration` or `src/test` source set and no test dependencies in `build.gradle` — and no client extension Spring Boot module in the repository has any. Adding a harness here would introduce a new pattern for the whole workspace rather than cover this change. The validation LPD-97785 asks for is an end-to-end run in production, which the new request logging exists to support.

## PR Check

Skipped. `pr-check` cannot run against this branch: it aborts on a dirty working tree, and the tree holds an unrelated in-progress change to the same subsystem. It also requires the branch to be rebased on the `liferay/liferay-portal` master, which would be wrong here — this work targets `master-temp-phase-1`, an integration branch 141 commits behind that master, and rebasing would destroy the base.
